### PR TITLE
fix: use gradle-nexus plugin for Maven Central publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Publish to Maven Central
-        run: ./gradlew publish
+        run: ./gradlew publishToSonatype closeSonatypeStagingRepository
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("jvm") version "1.9.22"
     kotlin("plugin.serialization") version "1.9.22"
     id("org.jetbrains.dokka") version "1.9.10"
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
     `maven-publish`
     signing
 }
@@ -80,14 +81,15 @@ publishing {
         }
     }
 
+}
+
+nexusPublishing {
     repositories {
-        maven {
-            name = "OSSRH"
-            url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
-            credentials {
-                username = System.getenv("OSSRH_USERNAME")
-                password = System.getenv("OSSRH_PASSWORD")
-            }
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            username.set(System.getenv("OSSRH_USERNAME"))
+            password.set(System.getenv("OSSRH_PASSWORD"))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `gradle-nexus/publish-plugin` to handle the full staging lifecycle (upload → close → release)
- The previous `maven-publish` plugin only uploaded artifacts but never closed/released the staging repository, so nothing appeared on Maven Central
- Update workflow to use `publishToSonatype closeSonatypeStagingRepository`

## Test plan
- [x] Build and tests pass locally
- [x] `publishToMavenLocal` generates all expected artifacts
- [x] Nexus plugin tasks (`publishToSonatype`, `closeSonatypeStagingRepository`) are registered
- [ ] Merge, create release, and verify artifact appears on Maven Central