### PR TITLE
chore: bump version to 2.2.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "ai.tuteliq"
-version = "2.2.1"
+version = "2.2.2"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Summary
- Bump version in `build.gradle.kts` from 2.2.1 to 2.2.2 to match the GitHub release tag