### PR TITLE
chore: bump version to 2.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ```kotlin
 dependencies {
-    implementation("ai.tuteliq:tuteliq:2.2.3")
+    implementation("ai.tuteliq:tuteliq:2.2.4")
 }
 ```
 
@@ -38,7 +38,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'ai.tuteliq:tuteliq:2.2.3'
+    implementation 'ai.tuteliq:tuteliq:2.2.4'
 }
 ```
 
@@ -48,7 +48,7 @@ dependencies {
 <dependency>
     <groupId>ai.tuteliq</groupId>
     <artifactId>tuteliq</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4</version>
 </dependency>
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "ai.tuteliq"
-version = "2.2.3"
+version = "2.2.4"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Summary
- Bump version to 2.2.4 in build.gradle.kts and README.md
- Fixes failed Maven Central publish (v2.2.3 already exists)