### PR TITLE
feat: add message_analysis to detection models

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ val result = client.detectGrooming(
 if (result.groomingRisk == GroomingRisk.HIGH) {
     println("Flags: ${result.flags}")  // ["secrecy", "isolation"]
 }
+
+// Per-message breakdown (optional, returned on conversation-aware endpoints)
+result.messageAnalysis?.forEach { m ->
+    println("Message ${m.messageIndex}: risk=${m.riskScore}, flags=${m.flags}, summary=${m.summary}")
+}
 ```
 
 ### Unsafe Content Detection

--- a/src/main/kotlin/ai/tuteliq/Models.kt
+++ b/src/main/kotlin/ai/tuteliq/Models.kt
@@ -190,6 +190,7 @@ data class GroomingResult(
     @SerialName("risk_score") val riskScore: Double,
     @SerialName("recommended_action") val recommendedAction: String,
     val language: String? = null,
+    @SerialName("message_analysis") val messageAnalysis: List<MessageAnalysis>? = null,
     @SerialName("language_status") val languageStatus: String? = null,
     @SerialName("external_id") val externalId: String? = null,
     val metadata: JsonObject? = null,
@@ -477,6 +478,17 @@ data class BreachResult(
 // =============================================================================
 
 /**
+ * Per-message analysis from conversation-aware detection.
+ */
+@Serializable
+data class MessageAnalysis(
+    @SerialName("message_index") val messageIndex: Int,
+    @SerialName("risk_score") val riskScore: Double,
+    val flags: List<String>,
+    val summary: String
+)
+
+/**
  * A detection category with tag, label, and confidence.
  */
 @Serializable
@@ -524,6 +536,7 @@ data class DetectionResult(
     @SerialName("language_status") val languageStatus: String,
     val evidence: List<DetectionEvidence>? = null,
     @SerialName("age_calibration") val ageCalibration: AgeCalibration? = null,
+    @SerialName("message_analysis") val messageAnalysis: List<MessageAnalysis>? = null,
     @SerialName("credits_used") val creditsUsed: Int? = null,
     @SerialName("processing_time_ms") val processingTimeMs: Double? = null,
     @SerialName("external_id") val externalId: String? = null,


### PR DESCRIPTION
## Summary
- Add `MessageAnalysis` serializable data class for per-message breakdown returned by conversation-aware detection endpoints
- Add `messageAnalysis` field to `DetectionResult` and `GroomingResult`
- Update README with usage example in grooming detection section

## Test plan
- [ ] Verify Kotlin serialization handles the new optional field
- [ ] Verify README example matches actual API response shape