### PR TITLE
feat: add session-based age and identity verification

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "ai.tuteliq"
-version = "2.2.4"
+version = "2.3.0"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/ai/tuteliq/Enums.kt
+++ b/src/main/kotlin/ai/tuteliq/Enums.kt
@@ -128,3 +128,45 @@ enum class Tier {
     @SerialName("business") BUSINESS,
     @SerialName("enterprise") ENTERPRISE
 }
+
+/**
+ * Verification mode for age/identity verification.
+ */
+@Serializable
+enum class VerificationMode {
+    @SerialName("age") AGE,
+    @SerialName("identity") IDENTITY
+}
+
+/**
+ * Document types accepted for verification.
+ */
+@Serializable
+enum class DocumentType {
+    @SerialName("passport") PASSPORT,
+    @SerialName("id_card") ID_CARD,
+    @SerialName("drivers_license") DRIVERS_LICENSE
+}
+
+/**
+ * Verification result status.
+ */
+@Serializable
+enum class VerificationStatus {
+    @SerialName("verified") VERIFIED,
+    @SerialName("failed") FAILED,
+    @SerialName("needs_review") NEEDS_REVIEW
+}
+
+/**
+ * Verification session status.
+ */
+@Serializable
+enum class VerificationSessionStatus {
+    @SerialName("pending") PENDING,
+    @SerialName("in_progress") IN_PROGRESS,
+    @SerialName("completed") COMPLETED,
+    @SerialName("failed") FAILED,
+    @SerialName("expired") EXPIRED,
+    @SerialName("cancelled") CANCELLED
+}

--- a/src/main/kotlin/ai/tuteliq/Models.kt
+++ b/src/main/kotlin/ai/tuteliq/Models.kt
@@ -838,3 +838,128 @@ data class UsageMonthlyResult(
     val recommendations: JsonObject? = null,
     val links: JsonObject
 )
+
+// =============================================================================
+// Verification
+// =============================================================================
+
+/**
+ * Input for creating a verification session.
+ */
+data class CreateVerificationSessionInput(
+    val mode: VerificationMode,
+    val documentType: DocumentType? = null
+)
+
+/**
+ * Verification session details.
+ * The `url` property maps from the API's `mobile_url` field.
+ */
+@Serializable
+data class VerificationSession(
+    @SerialName("session_id") val sessionId: String,
+    @SerialName("mobile_url") val url: String,
+    @SerialName("expires_at") val expiresAt: String,
+    val mode: VerificationMode,
+    @SerialName("verification_mode") val verificationMode: String? = null
+)
+
+/**
+ * Face match result from verification.
+ */
+@Serializable
+data class FaceMatchResult(
+    val matched: Boolean,
+    val confidence: Double,
+    val distance: Double? = null
+)
+
+/**
+ * Liveness check result from verification.
+ */
+@Serializable
+data class LivenessResult(
+    val valid: Boolean,
+    val reason: String? = null
+)
+
+/**
+ * Result of age verification.
+ */
+@Serializable
+data class AgeVerificationResult(
+    @SerialName("verification_id") val verificationId: String,
+    val status: VerificationStatus,
+    @SerialName("age_bracket") val ageBracket: String? = null,
+    @SerialName("is_minor") val isMinor: Boolean? = null,
+    val liveness: LivenessResult? = null,
+    @SerialName("face_match") val faceMatch: FaceMatchResult? = null,
+    @SerialName("failure_reasons") val failureReasons: List<String>? = null,
+    @SerialName("credits_used") val creditsUsed: Int? = null
+)
+
+/**
+ * Result of identity verification.
+ */
+@Serializable
+data class IdentityVerificationResult(
+    @SerialName("verification_id") val verificationId: String,
+    val status: VerificationStatus,
+    @SerialName("full_name") val fullName: String? = null,
+    @SerialName("date_of_birth") val dateOfBirth: String? = null,
+    @SerialName("document_type") val documentType: String? = null,
+    @SerialName("country_code") val countryCode: String? = null,
+    val liveness: LivenessResult? = null,
+    @SerialName("face_match") val faceMatch: FaceMatchResult? = null,
+    @SerialName("credits_used") val creditsUsed: Int? = null
+)
+
+/**
+ * Result of polling a verification session.
+ */
+@Serializable
+data class VerificationSessionResult(
+    @SerialName("session_id") val sessionId: String,
+    val status: VerificationSessionStatus,
+    val result: JsonObject? = null,
+    @SerialName("created_at") val createdAt: String? = null,
+    @SerialName("expires_at") val expiresAt: String? = null
+)
+
+/**
+ * Result of retrieving an age verification by ID.
+ */
+@Serializable
+data class VerificationRetrieveResult(
+    @SerialName("verification_id") val verificationId: String,
+    val status: VerificationStatus,
+    @SerialName("age_bracket") val ageBracket: String? = null,
+    @SerialName("is_minor") val isMinor: Boolean? = null,
+    val liveness: LivenessResult? = null,
+    @SerialName("face_match") val faceMatch: FaceMatchResult? = null,
+    @SerialName("created_at") val createdAt: String? = null
+)
+
+/**
+ * Result of retrieving an identity verification by ID.
+ */
+@Serializable
+data class IdentityRetrieveResult(
+    @SerialName("verification_id") val verificationId: String,
+    val status: VerificationStatus,
+    @SerialName("full_name") val fullName: String? = null,
+    @SerialName("date_of_birth") val dateOfBirth: String? = null,
+    @SerialName("document_type") val documentType: String? = null,
+    @SerialName("country_code") val countryCode: String? = null,
+    val liveness: LivenessResult? = null,
+    @SerialName("face_match") val faceMatch: FaceMatchResult? = null,
+    @SerialName("created_at") val createdAt: String? = null
+)
+
+/**
+ * Result of cancelling a verification session.
+ */
+@Serializable
+data class CancelVerificationSessionResult(
+    val message: String
+)

--- a/src/main/kotlin/ai/tuteliq/Tuteliq.kt
+++ b/src/main/kotlin/ai/tuteliq/Tuteliq.kt
@@ -848,6 +848,64 @@ class Tuteliq(
     }
 
     // =========================================================================
+    // Verification
+    // =========================================================================
+
+    /**
+     * Create a verification session.
+     *
+     * @param input Session configuration with mode and optional document type.
+     * @return VerificationSession with URL to redirect user.
+     */
+    suspend fun createVerificationSession(input: CreateVerificationSessionInput): VerificationSession {
+        val body = buildJsonObject {
+            put("mode", input.mode.name.lowercase())
+            input.documentType?.let { put("document_type", it.name.lowercase()) }
+        }
+        return request("/api/v1/verify/session", body)
+    }
+
+    /**
+     * Get the current status of a verification session.
+     *
+     * @param id The session ID from createVerificationSession.
+     * @return VerificationSessionResult with current status.
+     */
+    suspend fun getVerificationSession(id: String): VerificationSessionResult {
+        return request("GET", "/api/v1/verify/session/$id")
+    }
+
+    /**
+     * Cancel a verification session.
+     *
+     * @param id The session ID to cancel.
+     * @return CancelVerificationSessionResult with confirmation message.
+     */
+    suspend fun cancelVerificationSession(id: String): CancelVerificationSessionResult {
+        return request("DELETE", "/api/v1/verify/session/$id")
+    }
+
+    /**
+     * Retrieve a past age verification result.
+     *
+     * @param id The verification ID.
+     * @return VerificationRetrieveResult with verification details.
+     */
+    suspend fun getAgeVerification(id: String): VerificationRetrieveResult {
+        return request("GET", "/api/v1/verify/age/$id")
+    }
+
+    /**
+     * Retrieve a past identity verification result.
+     *
+     * @param id The verification ID.
+     * @return IdentityRetrieveResult with verification details.
+     */
+    suspend fun getIdentityVerification(id: String): IdentityRetrieveResult {
+        return request("GET", "/api/v1/verify/identity/$id")
+    }
+
+    // =========================================================================
     // Webhooks
     // =========================================================================
 

--- a/src/test/kotlin/ai/tuteliq/TuteliqTest.kt
+++ b/src/test/kotlin/ai/tuteliq/TuteliqTest.kt
@@ -4,6 +4,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.decodeFromString
 
 class TuteliqTest {
 
@@ -196,5 +198,139 @@ class TuteliqTest {
         assertEquals(2, input.messages.size)
         assertEquals(14, input.childAge)
         assertEquals("bullying", input.incidentType)
+    }
+
+    // =========================================================================
+    // Verification Enums
+    // =========================================================================
+
+    @Test
+    fun `VerificationMode enum has correct values`() {
+        assertEquals("age", VerificationMode.AGE.name.lowercase())
+        assertEquals("identity", VerificationMode.IDENTITY.name.lowercase())
+    }
+
+    @Test
+    fun `DocumentType enum has correct values`() {
+        assertEquals("passport", DocumentType.PASSPORT.name.lowercase())
+        assertEquals("id_card", DocumentType.ID_CARD.name.lowercase())
+        assertEquals("drivers_license", DocumentType.DRIVERS_LICENSE.name.lowercase())
+    }
+
+    @Test
+    fun `VerificationStatus enum has correct values`() {
+        assertEquals("verified", VerificationStatus.VERIFIED.name.lowercase())
+        assertEquals("failed", VerificationStatus.FAILED.name.lowercase())
+        assertEquals("needs_review", VerificationStatus.NEEDS_REVIEW.name.lowercase())
+    }
+
+    @Test
+    fun `VerificationSessionStatus enum has correct values`() {
+        assertEquals("pending", VerificationSessionStatus.PENDING.name.lowercase())
+        assertEquals("in_progress", VerificationSessionStatus.IN_PROGRESS.name.lowercase())
+        assertEquals("completed", VerificationSessionStatus.COMPLETED.name.lowercase())
+        assertEquals("failed", VerificationSessionStatus.FAILED.name.lowercase())
+        assertEquals("expired", VerificationSessionStatus.EXPIRED.name.lowercase())
+        assertEquals("cancelled", VerificationSessionStatus.CANCELLED.name.lowercase())
+    }
+
+    // =========================================================================
+    // Verification Models
+    // =========================================================================
+
+    @Test
+    fun `CreateVerificationSessionInput creation works`() {
+        val input = CreateVerificationSessionInput(
+            mode = VerificationMode.AGE,
+            documentType = DocumentType.PASSPORT
+        )
+        assertEquals(VerificationMode.AGE, input.mode)
+        assertEquals(DocumentType.PASSPORT, input.documentType)
+    }
+
+    @Test
+    fun `VerificationSession deserialization works`() {
+        val jsonStr = """
+            {
+                "session_id": "vs_abc123",
+                "mobile_url": "https://verify.tuteliq.ai/session/vs_abc123",
+                "expires_at": "2026-03-05T12:00:00Z",
+                "mode": "age"
+            }
+        """.trimIndent()
+        val json = Json { ignoreUnknownKeys = true }
+        val session = json.decodeFromString<VerificationSession>(jsonStr)
+
+        assertEquals("vs_abc123", session.sessionId)
+        assertEquals("https://verify.tuteliq.ai/session/vs_abc123", session.url)
+        assertEquals("2026-03-05T12:00:00Z", session.expiresAt)
+        assertEquals(VerificationMode.AGE, session.mode)
+    }
+
+    @Test
+    fun `AgeVerificationResult deserialization works`() {
+        val jsonStr = """
+            {
+                "verification_id": "vrf_123",
+                "status": "verified",
+                "age_bracket": "18-25",
+                "is_minor": false,
+                "credits_used": 10,
+                "liveness": {"valid": true},
+                "face_match": {"matched": true, "confidence": 0.95, "distance": 0.12}
+            }
+        """.trimIndent()
+        val json = Json { ignoreUnknownKeys = true }
+        val result = json.decodeFromString<AgeVerificationResult>(jsonStr)
+
+        assertEquals("vrf_123", result.verificationId)
+        assertEquals(VerificationStatus.VERIFIED, result.status)
+        assertEquals("18-25", result.ageBracket)
+        assertEquals(false, result.isMinor)
+        assertEquals(10, result.creditsUsed)
+        assertEquals(true, result.liveness?.valid)
+        assertEquals(true, result.faceMatch?.matched)
+        assertEquals(0.95, result.faceMatch?.confidence)
+    }
+
+    @Test
+    fun `IdentityVerificationResult deserialization works`() {
+        val jsonStr = """
+            {
+                "verification_id": "vrf_456",
+                "status": "verified",
+                "full_name": "John Doe",
+                "date_of_birth": "1990-01-15",
+                "document_type": "passport",
+                "country_code": "US",
+                "credits_used": 15
+            }
+        """.trimIndent()
+        val json = Json { ignoreUnknownKeys = true }
+        val result = json.decodeFromString<IdentityVerificationResult>(jsonStr)
+
+        assertEquals("vrf_456", result.verificationId)
+        assertEquals(VerificationStatus.VERIFIED, result.status)
+        assertEquals("John Doe", result.fullName)
+        assertEquals("1990-01-15", result.dateOfBirth)
+        assertEquals("passport", result.documentType)
+        assertEquals("US", result.countryCode)
+    }
+
+    @Test
+    fun `VerificationSessionResult deserialization works`() {
+        val jsonStr = """
+            {
+                "session_id": "vs_abc123",
+                "status": "completed",
+                "created_at": "2026-03-05T10:00:00Z",
+                "expires_at": "2026-03-05T12:00:00Z"
+            }
+        """.trimIndent()
+        val json = Json { ignoreUnknownKeys = true }
+        val result = json.decodeFromString<VerificationSessionResult>(jsonStr)
+
+        assertEquals("vs_abc123", result.sessionId)
+        assertEquals(VerificationSessionStatus.COMPLETED, result.status)
     }
 }


### PR DESCRIPTION
## Summary
- Add 4 verification enums: `VerificationMode`, `DocumentType`, `VerificationStatus`, `VerificationSessionStatus`
- Add 5 client methods: `createVerificationSession`, `getVerificationSession`, `cancelVerificationSession`, `getAgeVerification`, `getIdentityVerification`
- Add verification models with kotlinx.serialization support
- Bump version to 2.3.0
- 9 new tests for enums and model deserialization

## Test plan
- [ ] `./gradlew test` passes
- [ ] Manual verification with live API

🔒 Session-based flow: create session → redirect user to URL → poll for result