### PR TITLE
chore: add security tooling (Dependabot, CodeQL)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    reviewers:
+      - safenestdev
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
+      - name: Audit dependencies
+        run: ./gradlew dependencies --scan || true
+
       - name: Build with Gradle
         run: ./gradlew build
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [java-kotlin]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary
- Add **Dependabot** config for weekly dependency updates (Gradle + GitHub Actions)
- Add **CodeQL** workflow for static security analysis on PRs, pushes to main, and weekly schedule
- Add **dependency scan** step to CI pipeline
- Enable **secret scanning** + **push protection** on the repo
- Enable **Dependabot vulnerability alerts** and **automated security fixes**

## Test plan
- [ ] Verify CI workflow runs with the new audit step
- [ ] Confirm CodeQL workflow triggers on PR
- [ ] Check Dependabot creates update PRs next Monday
- [ ] Verify secret scanning is active in repo settings