### PR TITLE
docs: add supported languages section (27 languages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,18 @@ Enable `PII_REDACTION_ENABLED=true` on your Tuteliq API to automatically strip e
 
 ---
 
+## Supported Languages
+
+Tuteliq supports **27 languages** with automatic detection — no configuration required.
+
+**English** (stable) and **26 beta languages**: Spanish, Portuguese, Ukrainian, Swedish, Norwegian, Danish, Finnish, German, French, Dutch, Polish, Italian, Turkish, Romanian, Greek, Czech, Hungarian, Bulgarian, Croatian, Slovak, Lithuanian, Latvian, Estonian, Slovenian, Maltese, and Irish.
+
+All 24 EU official languages + Ukrainian, Norwegian, and Turkish. Each language includes culture-specific safety guidelines covering local slang, grooming patterns, self-harm coded vocabulary, and filter evasion techniques.
+
+See the [Language Support docs](https://docs.tuteliq.ai/languages) for details.
+
+---
+
 ## Support
 
 - **API Docs**: [docs.tuteliq.ai](https://docs.tuteliq.ai)

--- a/llms.txt
+++ b/llms.txt
@@ -26,6 +26,9 @@ val result = client.detectUnsafe(text = "content to check", ageGroup = "13-15")
 - Age Verification (Beta) — POST /v1/verification/age — 5 credits — Pro tier ($99/mo)+
 - Identity Verification (Beta) — POST /v1/verification/identity — 10 credits — Business tier ($349/mo)+
 
+## Supported Languages
+27 languages: English (stable), Spanish, Portuguese, Ukrainian, Swedish, Norwegian, Danish, Finnish, German, French, Dutch, Polish, Italian, Turkish, Romanian, Greek, Czech, Hungarian, Bulgarian, Croatian, Slovak, Lithuanian, Latvian, Estonian, Slovenian, Maltese, Irish (beta). Auto-detected, no configuration needed.
+
 ## Links
 - Website: https://tuteliq.ai
 - Documentation: https://docs.tuteliq.ai


### PR DESCRIPTION
## Summary
- Add **Supported Languages** section to README.md listing all 27 supported languages
- Add language support info to llms.txt for LLM discoverability

## Test plan
- [ ] Verify README renders correctly on GitHub